### PR TITLE
Shutdown implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,9 +53,6 @@ parking_lot = "0.9"
 #futures-preview = "=0.3.0-alpha.16"
 uuid = { version = "0.7", features = ["serde", "v4"] }
 
-[dev-dependencies]
-reqwest = "0.9.19"
-
 [profile.bench]
 panic = "unwind"
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ ego-tree = "0.6.0"
 lazy_static = "1.3.0"
 objekt = "0.1.2"
 signal-hook = "0.1.10"
+parking_lot = "0.9"
+
 
 #futures-preview = "=0.3.0-alpha.16"
 uuid = { version = "0.7", features = ["serde", "v4"] }

--- a/benches/bench_one_for_one.rs
+++ b/benches/bench_one_for_one.rs
@@ -1,0 +1,59 @@
+#![feature(test)]
+
+extern crate test;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bastion::bastion::Bastion;
+    use bastion::bastion::PLATFORM;
+    use bastion::config::BastionConfig;
+    use bastion::context::BastionContext;
+    use bastion::supervisor::SupervisionStrategy;
+    use log::LevelFilter;
+    use std::borrow::{Borrow, BorrowMut};
+    use std::sync::Once;
+    use std::{fs, thread, time};
+    use tokio::prelude::*;
+    use tokio::runtime::{Builder, Runtime};
+    use test::Bencher;
+
+
+    static INIT: Once = Once::new();
+
+    fn init() {
+        INIT.call_once(|| {
+            let config = BastionConfig {
+                log_level: LevelFilter::Debug,
+                in_test: true,
+            };
+            let bastion = Bastion::platform_from_config(config);
+        });
+    }
+
+    fn awaiting(time: u64) {
+        let ten_millis = time::Duration::from_millis(time);
+        thread::sleep(ten_millis);
+    }
+
+    #[bench]
+    fn spawn_with_supervisor_one_for_one(b: &mut Bencher) {
+        fn closure() {
+            init();
+
+            let message = "Supervision Message".to_string();
+
+            Bastion::spawn(
+                |p, msg| {
+                    panic!("root supervisor - spawn_at_root - 1");
+                },
+                message,
+            );
+
+            awaiting(100);
+        }
+
+        b.iter(|| closure());
+    }
+
+}

--- a/src/child.rs
+++ b/src/child.rs
@@ -15,6 +15,7 @@ impl<T> Message for T
 where
     T: Shell + Debug,
 {
+    #[inline(always)]
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-// Because if we can't trust, we can't make.
-#![forbid(unsafe_code)]
 #![feature(const_fn)]
 #![feature(unboxed_closures)]
 #![feature(fn_traits)]

--- a/src/runtime_manager.rs
+++ b/src/runtime_manager.rs
@@ -1,6 +1,7 @@
 use std::any::Any;
 
 pub(crate) trait RuntimeManager {
+    fn unstable_shutdown();
     fn runtime_shutdown_callback();
 }
 

--- a/src/runtime_system.rs
+++ b/src/runtime_system.rs
@@ -2,7 +2,8 @@ use crate::runtime_manager::FaultRecovery;
 use crate::supervisor::Supervisor;
 use ego_tree::Tree;
 use std::any::Any;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use parking_lot::Mutex;
 use tokio::runtime::{Builder, Runtime};
 
 pub struct RuntimeSystem {
@@ -15,7 +16,7 @@ impl RuntimeSystem {
         let runtime: Runtime = Builder::new()
             .panic_handler(|err| RuntimeSystem::panic_dispatcher(err))
             .before_stop(|| {
-                debug!("Executing thread stopping");
+                debug!("System is stopping...");
             })
             .build()
             .unwrap(); // Builder panic isn't a problem since we haven't started.

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -107,10 +107,12 @@ impl Supervisor {
                 if_killed.id = format!("{}::{}", if_killed.id, child_id);
 
                 let mut this_spv = self.clone();
+                let context_spv = self.clone();
 
                 let f = future::lazy(move || {
                     nt(
                         BastionContext {
+                            spv: Some(context_spv),
                             bcast_rx: Some(rx.clone()),
                             bcast_tx: Some(tx.clone()),
                         },

--- a/src/supervisor.rs
+++ b/src/supervisor.rs
@@ -135,7 +135,7 @@ impl Supervisor {
                     });
 
                 let ark = crate::bastion::PLATFORM.clone();
-                let mut runtime = ark.lock().unwrap();
+                let mut runtime = ark.lock();
                 let shared_runtime = &mut runtime.runtime;
                 shared_runtime.spawn(k);
             }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -181,4 +181,30 @@ mod tests {
 
         awaiting(500);
     }
+
+//    #[test]
+//    fn spawn_over_context() {
+//        init();
+//
+//        let panicked_message = "Panicked Children Message".to_string();
+//        let stable_message = "Stable Children Message".to_string();
+//
+//        Bastion::supervisor("background-worker", "new-system")
+//            .strategy(SupervisionStrategy::OneForAll)
+//            .children(
+//                |p: BastionContext, msg| {
+//                    println!("new supervisor - panic_process - 1");
+//
+//                    let children_scale = 1;
+//                    p.spawn(|bc, msg| {
+//                        println!("Spawned from context");
+//                    }, msg, children_scale);
+//                },
+//                panicked_message,
+//                1_i32,
+//            )
+//            .launch();
+//
+//        awaiting(500);
+//    }
 }

--- a/tests/test_shutdown.rs
+++ b/tests/test_shutdown.rs
@@ -1,0 +1,45 @@
+#[cfg(test)]
+mod tests {
+    use bastion::prelude::*;
+    use log::LevelFilter;
+    use std::{fs, thread, time};
+
+    fn awaiting(time: u64) {
+        let ten_millis = time::Duration::from_millis(time);
+        thread::sleep(ten_millis);
+    }
+
+    #[test]
+    fn test_shutdown() {
+        let config = BastionConfig {
+            log_level: LevelFilter::Debug,
+            in_test: true,
+        };
+        Bastion::platform_from_config(config);
+
+        let message = "S1".to_string();
+        let message2 = "S2".to_string();
+
+        Bastion::spawn(
+            |p, msg| {
+                println!("root supervisor - spawn_at_root - 1");
+            },
+            message,
+        );
+
+        Bastion::supervisor("k", "m");
+
+        awaiting(10);
+
+        Bastion::spawn(
+            |p, msg| {
+                println!("root supervisor - spawn_at_root - 2");
+            },
+            message2,
+        );
+
+        println!("Shutdown initiated");
+
+        Bastion::force_shutdown();
+    }
+}


### PR DESCRIPTION
Implementation of #13.

This implementation was needed for some use cases.
Programmatical shutdown usage is not safe and against the philosophy of this crate.
It shouldn't be used to stop the system.
