### PR TITLE
Build on windows

### DIFF
--- a/.appveyor.yaml
+++ b/.appveyor.yaml
@@ -1,0 +1,26 @@
+environment:
+  matrix:
+    - TARGET: i686-pc-windows-msvc
+      CHANNEL: stable
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: stable
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: stable
+    - TARGET: i686-pc-windows-msvc
+      CHANNEL: nightly
+    - TARGET: x86_64-pc-windows-gnu
+      CHANNEL: nightly
+    - TARGET: x86_64-pc-windows-msvc
+      CHANNEL: nightly
+
+install:
+  - curl -sSf -o rustup-init.exe https://win.rustup.rs
+  - rustup-init.exe --default-host %TARGET% --default-toolchain %CHANNEL% -y
+  - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin;C:\msys64\mingw64\bin;C:\msys64\usr\bin;
+  - rustc -Vv
+  - cargo -V
+
+build: false
+
+test_script:
+  - cargo test --release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ maintenance = { status = "actively-developed" }
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+ctrlc = "3.1.3"
 tokio = "^0.1"
 tokio-executor = "0.1.8"
 tokio-threadpool = "0.1.15"
@@ -46,7 +47,6 @@ backtrace = "0.3.32"
 ego-tree = "0.6.0"
 lazy_static = "1.3.0"
 objekt = "0.1.2"
-signal-hook = "0.1.10"
 parking_lot = "0.9"
 
 

--- a/src/bastion.rs
+++ b/src/bastion.rs
@@ -20,6 +20,7 @@ use tokio::prelude::*;
 use tokio::runtime::Runtime;
 use uuid::Uuid;
 use std::mem;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 lazy_static! {
     // Platform which contains runtime system.

--- a/src/bastion.rs
+++ b/src/bastion.rs
@@ -12,7 +12,6 @@ use env_logger::Builder;
 use futures::future::poll_fn;
 use lazy_static::lazy_static;
 use log::LevelFilter;
-use signal_hook::{iterator::Signals, SIGINT};
 use std::panic::AssertUnwindSafe;
 use std::sync::Arc;
 use parking_lot::Mutex;
@@ -329,16 +328,14 @@ impl RuntimeManager for Bastion {
 
     fn runtime_shutdown_callback() {
         let mut entered = tokio_executor::enter().expect("main thread_local runtime lock");
-        let signals = Signals::new(&[SIGINT]).unwrap();
-
+        let running = Arc::new(AtomicBool::new(true));
+        let r = running.clone();
+        let _ = ctrlc::set_handler(move || {
+            r.store(false, Ordering::SeqCst);
+        }).unwrap();
         entered
             .block_on(poll_fn(|| {
-                for sig in signals.forever() {
-                    match sig {
-                        signal_hook::SIGINT => break,
-                        _ => unreachable!(),
-                    }
-                }
+                while running.load(Ordering::SeqCst) {}
                 CLOSE_OVER
             }))
             .expect("cannot shutdown");


### PR DESCRIPTION
This PR adds support for windows. The PR adds a new appveyor file that will build the project on stable.

This PR is blocked by stable support which should land with #20. Appveyor also needs to be hooked up to the app so that we can get the nice green check before merging. 

This was first discussed in #17 